### PR TITLE
Unused input argument in _angle_to_length method 

### DIFF
--- a/solarbextrapolation/extrapolators/base.py
+++ b/solarbextrapolation/extrapolators/base.py
@@ -105,7 +105,7 @@ class Extrapolators(object):
         Uses the small angle approximation.
         """
         r = self.map_boundary_data.dsun - self.map_boundary_data.rsun_meters
-        length = (r * self.map_boundary_data.xrange.to(u.radian))
+        length = (r * arc.to(u.radian))
         return length.to(u.m, equivalencies=u.dimensionless_angles())
 
     def _to_SI(self, **kwargs):


### PR DESCRIPTION
In `extrapolators.base.Extrapolators` the method for converting angles to lengths did not use the input `arc`. Instead, `self.map_boundary_data.xrange` was hardcoded. It seems like this might cause problems if, for example, this method is called on `self.yrange` (as it is in `_extrapolation` method).
