### PR TITLE
Map3D and extrapolator dimension mismatch fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,8 +42,11 @@ except ImportError:
 from astropy_helpers.sphinx.conf import *
 
 # Get configuration information from setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
 conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
 

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,11 @@ if on_rtd:
 # ------------------------------------------------------------------------------
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 

--- a/solarbextrapolation/analyticalmodels/titov_demoulin_equilibrium.py
+++ b/solarbextrapolation/analyticalmodels/titov_demoulin_equilibrium.py
@@ -32,7 +32,7 @@ from scipy import interpolate
 from astropy import units as u
 
 
-# Imports for numba JIT compilation 
+# Imports for numba JIT compilation
 from numba import double
 from numba.decorators import jit, autojit
 
@@ -56,7 +56,7 @@ qua_TD_q = 100.0 * 10**12 * u.m * u.m * u.T  # T m^2  # ABS Charge of +q and -q.
 qua_TD_a = 31.0*10**6 * u.m  # m      # Radius of uniform current I.
 
 qua_TD_I_0 = -7.0*10**12 * u.A # A # - 7.0 TA #
-flo_TD_li = 1.0 / 2.0 # for uniform distribution of current over toroidal flux tube. 
+flo_TD_li = 1.0 / 2.0 # for uniform distribution of current over toroidal flux tube.
 
 # Convert all these into SI units
 flo_TD_L   = qua_TD_L.to(u.m).value
@@ -76,7 +76,7 @@ TD_q = 100.0*10**12   # T m^2  # ABS Charge of +q and -q.
 TD_a = 31.0*10**6  # m      # Radius of uniform current I.
 
 TD_I_0 = -7.0*10**12 # A # - 7.0 TA #
-TD_li = 1.0/2.0 # for uniform distribution of current over toroidal flux tube. 
+TD_li = 1.0/2.0 # for uniform distribution of current over toroidal flux tube.
 TD_I = 8.0 * pi * TD_q * TD_L * TD_R * (TD_R**2.0 + TD_L**2)**(-3.0/2.0) / ( mu_0 * (np.log(8.0 * TD_R / TD_a) - (3.0/2.0) + (TD_li / 2.0)) ) # 11 # 11000 GA # Equilibrium
 
 
@@ -121,7 +121,7 @@ def chi_safe(X, val, debug = 0):
 
     # Debugging
     if debug > 0:
-        print 'chi_safe(' + str(X) + '): ' + str(out)
+        print('chi_safe(' + str(X) + '): ' + str(out))
     # Output
     return out
 
@@ -132,18 +132,18 @@ def r_perpendicular_scalar(y, z, d, debug = 0):
 
     # Debugging
     if debug > 0:
-        print 'r_perpendicular_scalar: ' + str(out)
+        print('r_perpendicular_scalar: ' + str(out))
     # Output
     return out
 
-# 
+#
 def rho(x, y, z, R, d, debug = 0):
     # Output
     out = ( x**2.0 + (r_perpendicular_scalar(y, z, d, debug - 2) - R)**2.0 )**(0.5)
 
     # Debugging
     if debug > 0:
-        print 'rho: ' + str(out)
+        print('rho: ' + str(out))
     # Output
     return out
 
@@ -151,7 +151,7 @@ def rho(x, y, z, R, d, debug = 0):
 def theta_hat(y, z, d, debug = 0):
     # r_perp
     r_perp = r_perpendicular_scalar(y, z, d, debug - 2)
-    
+
     # Components
     theta_hat_x = 0.0
     theta_hat_y = - ( ( z + d ) / r_perp )
@@ -162,7 +162,7 @@ def theta_hat(y, z, d, debug = 0):
 
     # Debugging
     if debug > 0:
-        print 'theta_hat: ' + str(out)
+        print('theta_hat: ' + str(out))
     # Output
     return out
 
@@ -171,7 +171,7 @@ def theta_hat(y, z, d, debug = 0):
 def B_theta(x, y, z, a, d, R, I, I_0, debug = 0):
     # Find rho
     rho_val = rho(x, y, z, R, d, debug - 2)
-    
+
     # The parts.
     part_1  = ( mu_0 * I_0 ) / (2.0 * pi )
     part_2a = R**(-2.0)
@@ -185,24 +185,24 @@ def B_theta(x, y, z, a, d, R, I, I_0, debug = 0):
     # Now put it together.
     scalar = part_1 * (part_2 + part_3 - part_4)
     vector = theta_hat(y, z, d)
-    
+
     # Output
     out = np.array([scalar * vector[0], scalar * vector[1], scalar * vector[2]])
 
     # Debugging
     if debug > 0:
-        print 'B_theta: ' + str(out)
+        print('B_theta: ' + str(out))
     if debug > 1:
-        print '  B_theta  part_1: ' + str(part_1)
-        print '  B_theta  part_2: ' + str(part_2)
-        print '  B_theta    part_2a: ' + str(part_2a)
-        print '  B_theta    part_2b: ' + str(part_2b)
-        print '  B_theta    part_2c: ' + str(part_2c)
-        print '  B_theta    part_2d: ' + str(part_2d)
-        print '  B_theta  part_3: ' + str(part_3)
-        print '  B_theta  part_4: ' + str(part_4)
-        print '  B_theta  scalar: ' + str(scalar)
-        print '  B_theta  vector: ' + str(vector) + '\n'
+        print ('  B_theta  part_1: ' + str(part_1))
+        print ('  B_theta  part_2: ' + str(part_2))
+        print ('  B_theta    part_2a: ' + str(part_2a))
+        print ('  B_theta    part_2b: ' + str(part_2b))
+        print ('  B_theta    part_2c: ' + str(part_2c))
+        print ('  B_theta    part_2d: ' + str(part_2d))
+        print ('  B_theta  part_3: ' + str(part_3))
+        print ('  B_theta  part_4: ' + str(part_4))
+        print ('  B_theta  scalar: ' + str(scalar))
+        print ('  B_theta  vector: ' + str(vector) + '\n')
     # Output
     return out
 
@@ -222,40 +222,40 @@ def r_plusminus(x, y, z, L, d, sign, debug = 0):
 
     # Output B_q vector.
     out = np.array([ r_x, r_y, r_z ])
-    
+
     # Debugging
     if debug > 0:
-        print 'r_plusminus(..., ' + str(sign) + '): ' + str(out)
+        print('r_plusminus(..., ' + str(sign) + '): ' + str(out))
     # Output
     return out
 
 # Returns the B-q vector (numpy array) at given x, y, z.
 def B_q(x, y, z, L, d, q, debug = 0):
-    # Getting the r+- vectors    
+    # Getting the r+- vectors
     r_plus = r_plusminus(x, y, z, L, d, 1.0, debug - 2)
     r_minus = r_plusminus(x, y, z, L, d, -1.0, debug - 2)
-    
+
     # Get the modulus of these
     mod_r_plus = (r_plus[0]**2.0 + r_plus[1]**2.0 + r_plus[2]**2.0)**(0.5)
     mod_r_minus = (r_minus[0]**2.0 + r_minus[1]**2.0 + r_minus[2]**2.0)**(0.5)
-    
+
     # Get the two fractions form (20)
     frac_r_plus = r_plus / (mod_r_plus**3.0)
     frac_r_minus = r_minus / (mod_r_minus**3.0)
-    
+
     # Output B_q vector.
     out = q * np.subtract(frac_r_plus, frac_r_minus)
-    
+
     # Debugging
     if debug > 0:
-        print 'B_q: ' + str(out)
+        print('B_q: ' + str(out))
     if debug > 1:
-        print '  B_q  r_plus: ' + str(r_plus)
-        print '  B_q  r_minus: ' + str(r_minus)
-        print '  B_q  mod_r_plus: ' + str(mod_r_plus)
-        print '  B_q  mod_r_minus: ' + str(mod_r_minus)
-        print '  B_q  frac_r_plus: ' + str(frac_r_plus)
-        print '  B_q  frac_r_minus: ' + str(frac_r_minus) + '\n'
+        print('  B_q  r_plus: ' + str(r_plus))
+        print('  B_q  r_minus: ' + str(r_minus))
+        print('  B_q  mod_r_plus: ' + str(mod_r_plus))
+        print('  B_q  mod_r_minus: ' + str(mod_r_minus))
+        print('  B_q  frac_r_plus: ' + str(frac_r_plus))
+        print('  B_q  frac_r_minus: ' + str(frac_r_minus) + '\n')
     # Output
     return out
 
@@ -280,47 +280,47 @@ def r_perpendicular_vector(y, z, d, debug = 0):
 
     # Debugging
     if debug > 0:
-        print 'r_perpendicular_vector: ' + str(out)
+        print('r_perpendicular_vector: ' + str(out))
     # Output
     return out
 
 
 def k_func(x, y, z, d, R, debug = 0):
-    # Parameters    
+    # Parameters
     r_perp = r_perpendicular_scalar(y, z, d, debug - 2)
-    
+
     # fraction inside root
     frac = (r_perp * R)/((r_perp + R)**2.0 + x**2.0)
-    
+
     # Output
     out = 2 * (frac)**(0.5)
-    
+
     # Debugging
     if debug > 0:
-        print 'k_a_func: ' + str(out)
+        print('k_a_func: ' + str(out))
     if debug > 1:
-        print '  k_func  r_perp: ' + str(r_perp)
-        print '  k_func  frac: ' + str(frac)
+        print('  k_func  r_perp: ' + str(r_perp))
+        print('  k_func  frac: ' + str(frac))
     # Output
     return out
 
 
 def k_a_func(y, z, d, R, a, debug = 0):
-    # Parameters    
+    # Parameters
     r_perp = r_perpendicular_scalar(y, z, d, debug - 2)
-    
+
     # fraction inside root
     frac = (r_perp * R)/(4.0 * r_perp * R + a**2.0)
-    
+
     # Output
     out = 2 * (frac)**(0.5)
-    
+
     # Debugging
     if debug > 0:
-        print 'k_a_func: ' + str(out)
+        print('k_a_func: ' + str(out))
     if debug > 1:
-        print '  k_a_func  r_perp: ' + str(r_perp)
-        print '  k_a_func  frac: ' + str(frac)        
+        print('  k_a_func  r_perp: ' + str(r_perp))
+        print('  k_a_func  frac: ' + str(frac))
     # Output
     return out
 
@@ -328,10 +328,10 @@ def k_a_func(y, z, d, R, a, debug = 0):
 def A_of_k(k, debug = 0):
     # Output
     out = (k**(-1.0))*((2.0 - k**2.0) * scipy.special.ellipk(k))
-    
+
     # Debugging
     if debug > 0:
-        print 'A_of_k(' + str(k) + '): ' + str(out)
+        print('A_of_k(' + str(k) + '): ' + str(out))
     # Output
     return out
 
@@ -340,55 +340,55 @@ def A_prime_of_k(k, debug = 0):
     numerator_1 = (2.0 - k**2.0) * scipy.special.ellipe(k)
     numerator_2 = 2.0 * (1.0 - k**2.0) * scipy.special.ellipk(k)
     denominator = k**2.0 * (1.0 - k**2.0)
-    
+
     # Output
     out = (numerator_1 - numerator_2) / denominator
-    
+
     # Debugging
     if debug > 0:
-        print 'A_prime_of_k: ' + str(out)
+        print ('A_prime_of_k: ' + str(out))
     if debug > 1:
-        print '  A_prime_of_k  numerator_1: ' + str(numerator_1)
-        print '  A_prime_of_k  numerator_2: ' + str(numerator_2)
-        print '  A_prime_of_k  denominator: ' + str(denominator)
+        print('  A_prime_of_k  numerator_1: ' + str(numerator_1))
+        print('  A_prime_of_k  numerator_2: ' + str(numerator_2))
+        print('  A_prime_of_k  denominator: ' + str(denominator))
     # Output
     return out
 
 def A_tilde_I_in(k, k_a, r_perp, R, I, debug = 0):
-    # Building the parts    
+    # Building the parts
     part_1 = (mu_0 * I)/(2.0 * pi)
     part_2 = ((R)/(r_perp))**(0.5)
     part_3 = A_of_k(k_a, debug - 2) + A_prime_of_k(k_a, debug - 2) * (k - k_a)
-    
+
     # Output
     out = part_1 * part_2 * part_3
-    
+
     # Debugging
     if debug > 0:
-        print 'A_tilde_I_in: ' + str(out)
+        print('A_tilde_I_in: ' + str(out))
     if debug > 1:
-        print '  A_tilde_I_in  part_1: ' + str(part_1)
-        print '  A_tilde_I_in  part_2: ' + str(part_2)
-        print '  A_tilde_I_in  part_3: ' + str(part_3)
+        print('  A_tilde_I_in  part_1: ' + str(part_1))
+        print('  A_tilde_I_in  part_2: ' + str(part_2))
+        print('  A_tilde_I_in  part_3: ' + str(part_3))
     # Output
     return out
 
 def A_I_ex(k, r_perp, R, I, debug = 0):
-    # Building the parts    
+    # Building the parts
     part_1 = (mu_0 * I)/(2.0 * pi)
     part_2 = ((R)/(r_perp))**(0.5)
     part_3 = A_of_k(k)
-    
+
     # Output
     out = part_1 * part_2 * part_3
 
     # Debugging
     if debug > 0:
-        print 'A_I_ex: ' + str(out)
+        print('A_I_ex: ' + str(out))
     if debug > 1:
-        print '  A_I_ex  part_1: ' + str(part_1)
-        print '  A_I_ex  part_2: ' + str(part_2)
-        print '  A_I_ex  part_3: ' + str(part_3)
+        print('  A_I_ex  part_1: ' + str(part_1))
+        print('  A_I_ex  part_2: ' + str(part_2))
+        print('  A_I_ex  part_3: ' + str(part_3))
     # Output
     return out
 
@@ -398,7 +398,7 @@ def A_I(x, y, z, R, a, d, I, debug = 0):
     k = k_func(x, y, z, d, R, debug - 2)
     k_a = k_a_func(y, z, d, R, a, debug - 2)
     r_perp = r_perpendicular_scalar(y, z, d, debug - 2)
-    
+
     # Parts
     part_1 = chi_safe(a - rho_val, A_tilde_I_in(k, k_a, r_perp, R, I))
     part_2 = chi_safe(rho_val - a, A_I_ex(k, r_perp, R, I))
@@ -406,10 +406,10 @@ def A_I(x, y, z, R, a, d, I, debug = 0):
 
     # Debugging
     if debug > 0:
-        print 'A_I: ' + str(out)
+        print('A_I: ' + str(out))
     if debug > 1:
-        print '  A_I  part_1: ' + str(part_1)
-        print '  A_I  part_2: ' + str(part_2)
+        print('  A_I  part_1: ' + str(part_1))
+        print('  A_I  part_2: ' + str(part_2))
     # Output
     return out
 
@@ -417,10 +417,10 @@ def A_I(x, y, z, R, a, d, I, debug = 0):
 def interpolate_A_I_from_r_perp(R, a, d, I, r_perp_max, resolution = 100000, debug = 0):
     # parameters to pass in:
     dr_perp = 1.0 * r_perp_max / resolution
-    
+
     # 1D array of vectors for A_I(r_perp)
     npm_A_I = np.zeros((resolution, 2))
-    
+
     # If we lock x = 0, z = -d then we know r_perp = y
     x = 0.0
     z = - d
@@ -440,19 +440,19 @@ def interpolate_A_I_from_r_perp(R, a, d, I, r_perp_max, resolution = 100000, deb
 
 # dr_perp should be notably smaller then the grid size in the original 3D space.
 def dA_I_dr_perp(r_perp, dr_perp, R, a, d, I, interpolator, debug = 0):
-    # Get my 2 values of A_I   
+    # Get my 2 values of A_I
     A_Ia = interpolator(r_perp - dr_perp)
     A_Ib = interpolator(r_perp + dr_perp)
-    
+
     # Numerical differentiation
     out = (A_Ib - A_Ia) / (2.0 * dr_perp)
-    
+
     # Debugging
     if debug > 0:
-        print 'dA_I_dr_perp: ' + str(out)
+        print('dA_I_dr_perp: ' + str(out))
     if debug > 1:
-        print '  dA_I_dr_perp  A_Ia: ' + str(A_Ia)
-        print '  dA_I_dr_perp  A_Ib: ' + str(A_Ib)
+        print('  dA_I_dr_perp  A_Ia: ' + str(A_Ia))
+        print('  dA_I_dr_perp  A_Ib: ' + str(A_Ib))
     return out
 
 
@@ -463,13 +463,13 @@ def dA_I_dx(x, y, z, R, a, d, I, Dx, debug = 0):
 
     # Out
     out = (A_I_x_plus_1 - A_I_x_minus_1)/(2.0*Dx)
-    
+
     # Debugging
     if debug > 0:
-        print 'dA_I_dx: ' + str(out)
+        print('dA_I_dx: ' + str(out))
     if debug > 1:
-        print '  dA_I_dx  A_I_x_minus_1: ' + str(A_I_x_minus_1)
-        print '  dA_I_dx  A_I_x_plus_1: ' + str(A_I_x_plus_1)        
+        print('  dA_I_dx  A_I_x_minus_1: ' + str(A_I_x_minus_1))
+        print('  dA_I_dx  A_I_x_plus_1: ' + str(A_I_x_plus_1))
     # Output
     return out
 
@@ -481,27 +481,27 @@ def B_I(x, y, z, R, a, d, I, Dx, A_I_r_perp_interpolator, debug = 0):
     dA_I_dx_val = dA_I_dx(x, y, z, R, a, d, I, Dx, debug - 2)
     r_perp = r_perpendicular_scalar(y, z, d, debug - 2)
     r_perp_vec = r_perpendicular_vector(y, z, d, debug - 2)
-    
+
     # To get dA_I_dr_perp we use inperpolation to get A_I(r_perp).
     dA_I_dr_perp_val = dA_I_dr_perp(r_perp, Dx * 0.2, R, a, d, I, A_I_r_perp_interpolator, debug - 2)
-    
+
     # Parts
     part_1 = - dA_I_dx_val * ( r_perp_vec / r_perp )
     #print '1: ' + str(part_1)
     part_2 = np.array([dA_I_dr_perp_val + ( A_I_val / r_perp ), 0, 0])
-    #print '2: ' + str(part_2) + '\n'    
-    
+    #print '2: ' + str(part_2) + '\n'
+
     # Output
     out = np.add(part_1,part_2)
-    
+
     # Debugging
     if debug > 0:
-        print 'B_I: ' + str(out)
+        print('B_I: ' + str(out))
     if debug > 1:
-        print '  B_I  part_1: ' + str(part_1)
-        print '  B_I  part_2: ' + str(part_2) + '\n'
+        print('  B_I  part_1: ' + str(part_1))
+        print('  B_I  part_2: ' + str(part_2) + '\n')
     return out
-    
+
 
 if __name__ == '__main__':
     # User-specified parameters
@@ -509,7 +509,7 @@ if __name__ == '__main__':
     x_range = ( -80.0, 80 ) * u.Mm
     y_range = ( -80.0, 80 ) * u.Mm
     z_range =  ( 0.0, 120 ) * u.Mm
-    
+
     # Derived parameters (make SI where applicable)
     x_0 = x_range[0].to(u.m).value
     Dx = (( x_range[1] - x_range[0] ) / ( tup_shape[0] * 1.0 )).to(u.m).value
@@ -520,11 +520,11 @@ if __name__ == '__main__':
     z_0 = z_range[0].to(u.m).value
     Dz = (( z_range[1] - z_range[0] ) / ( tup_shape[2] * 1.0 )).to(u.m).value
     z_size = Dy * tup_shape[2]
-    
-    # For B_I field only, to save re-creating this interpolator for every cell.
-    A_I_r_perp_interpolator = interpolate_A_I_from_r_perp(flo_TD_R, flo_TD_a, flo_TD_d, flo_TD_I, (x_size**2 + y_size**2 + z_size**2)**(0.5)*1.2, 1000`0)
 
-    field = np.zeros( ( tup_shape[0], tup_shape[1], tup_shape[2], 3 ) ) 
+    # For B_I field only, to save re-creating this interpolator for every cell.
+    A_I_r_perp_interpolator = interpolate_A_I_from_r_perp(flo_TD_R, flo_TD_a, flo_TD_d, flo_TD_I, (x_size**2 + y_size**2 + z_size**2)**(0.5)*1.2, 10000)
+
+    field = np.zeros( ( tup_shape[0], tup_shape[1], tup_shape[2], 3 ) )
     for i in range(0, tup_shape[0]):
         for j in range(0, tup_shape[1]):
             for k in range(0, tup_shape[2]):
@@ -532,23 +532,18 @@ if __name__ == '__main__':
                 x_pos = x_0 + ( i + 0.5 ) * Dx
                 y_pos = y_0 + ( j + 0.5 ) * Dy
                 z_pos = z_0 + ( k + 0.5 ) * Dz
-                
+
                 #field[i,j,k] = B_theta(x_pos, y_pos, z_pos, flo_TD_a, flo_TD_d, flo_TD_R, flo_TD_I, flo_TD_I_0)
                 #field[i,j,k] = B_q(x_pos, y_pos, z_pos, flo_TD_L, flo_TD_d, flo_TD_q)
                 #field[i,j,k] = B_I(x_pos, y_pos, z_pos, flo_TD_R, flo_TD_a, flo_TD_d, flo_TD_I, Dx, A_I_r_perp_interpolator)
                 field[i,j,k] = B_theta(x_pos, y_pos, z_pos, flo_TD_a, flo_TD_d, flo_TD_R, flo_TD_I, flo_TD_I_0) + B_q(x_pos, y_pos, z_pos, flo_TD_L, flo_TD_d, flo_TD_q) + B_I(x_pos, y_pos, z_pos, flo_TD_R, flo_TD_a, flo_TD_d, flo_TD_I, Dx, A_I_r_perp_interpolator)
-                                
-                
-     
-        
+
+
+
+
     map_field = Map3D( field, {}, xrange=x_range, yrange=y_range, zrange=z_range )
     np_boundary_data = field[:,:,0,2].T
     dummyDataToMap(np_boundary_data, x_range, y_range)
-    
+
     #dic_boundary_data = { 'datavals': np_boundary_data.data.shape[0]**2, 'dsun_obs': 147065396219.34,  }
     visualise(map_field, scale=1.0*u.Mm, show_volume_axes=True, debug=True)
-     
-        
-        
-        
-    

--- a/solarbextrapolation/extrapolators/base.py
+++ b/solarbextrapolation/extrapolators/base.py
@@ -92,8 +92,8 @@ class Extrapolators(object):
         #print 'help(u): ' + str(help(u))
         #print '\n\n'
         self.zrange = kwargs.get('zrange', u.Quantity([0.0, 1.0] * u.Mm) )
-        self.shape = np.asarray([self.map_boundary_data.data.shape[0],
-                      self.map_boundary_data.data.shape[1],
+        self.shape = np.asarray([self.map_boundary_data.data.shape[1],
+                      self.map_boundary_data.data.shape[0],
                       long(kwargs.get('zshape', 1L))])
         self.filepath = kwargs.get('filepath', None)
         self.routine = kwargs.get('extrapolator_routine', type(self))

--- a/solarbextrapolation/extrapolators/base.py
+++ b/solarbextrapolation/extrapolators/base.py
@@ -105,7 +105,7 @@ class Extrapolators(object):
         Uses the small angle approximation.
         """
         r = self.map_boundary_data.dsun - self.map_boundary_data.rsun_meters
-        length = (r * self.map_boundary_data.xrange.to(u.radian))
+        length = (r * arc.to(u.radian))
         return length.to(u.m, equivalencies=u.dimensionless_angles())
 
     def _to_SI(self, **kwargs):

--- a/solarbextrapolation/extrapolators/potential_field_extrapolator_numba.py
+++ b/solarbextrapolation/extrapolators/potential_field_extrapolator_numba.py
@@ -19,7 +19,7 @@ def phi_extrapolation_numba(boundary, shape, Dx, Dy, Dz):
     """
 
     # Create the empty numpy volume array.
-    D = np.empty((shape[0], shape[1], shape[2]), dtype=np.float)
+    D = np.empty((shape[1], shape[0], shape[2]), dtype=np.float)
 
     D = outer_loop(D, Dx, Dy, Dz, boundary)
 
@@ -32,8 +32,8 @@ def outer_loop(D, Dx, Dy, Dz, boundary):
     # From Sakurai 1982 P306, we submerge the monopole
     z_submerge = Dz / np.sqrt(2.0 * np.pi)
     # Iterate though the 3D space.
-    for i in range(0, shape[0]):
-        for j in range(0, shape[1]):
+    for i in range(0, shape[1]):
+        for j in range(0, shape[0]):
             for k in range(0, shape[2]):
                 # Position of point in 3D space
                 x = i * Dx
@@ -51,8 +51,8 @@ def inner_loop(shape, Dx, Dy, x, y, z, boundary, z_submerge):
     # Variable holding running total for the contributions to point.
     point_phi_sum = 0.0
     # Iterate through the boundary data.
-    for i_prime in range(0, shape[0]):
-        for j_prime in range(0, shape[1]):
+    for i_prime in range(0, shape[1]):
+        for j_prime in range(0, shape[0]):
             # Position of contributing point on 2D boundary
             xP = i_prime * Dx
             yP = j_prime * Dy
@@ -84,5 +84,3 @@ def Gn_5_2_29(x, y, z, xP, yP, DxDy_val, z_submerge):
 
     floOut = 1.0 / (2.0 * np.pi * floModDr)
     return floOut
-
-

--- a/solarbextrapolation/extrapolators/potential_field_extrapolator_numba.py
+++ b/solarbextrapolation/extrapolators/potential_field_extrapolator_numba.py
@@ -41,7 +41,7 @@ def outer_loop(D, Dx, Dy, Dz, boundary):
                 z = k * Dz
 
                 # Now add this to the 3D grid.
-                D[i, j, k] = inner_loop(shape, Dx, Dy, x, y, z, boundary, z_submerge)
+                D[j, i, k] = inner_loop(shape, Dx, Dy, x, y, z, boundary, z_submerge)
     return D
 
 
@@ -58,7 +58,7 @@ def inner_loop(shape, Dx, Dy, x, y, z, boundary, z_submerge):
             yP = j_prime * Dy
 
             # Find the components for this contribution product
-            B_n = boundary[i_prime, j_prime]
+            B_n = boundary[j_prime, i_prime]
             G_n = Gn_5_2_29(x, y, z, xP, yP, DxDy, z_submerge)
 
             # Add the contributions

--- a/solarbextrapolation/extrapolators/potential_field_extrapolator_python.py
+++ b/solarbextrapolation/extrapolators/potential_field_extrapolator_python.py
@@ -53,7 +53,7 @@ def phi_extrapolation_python(boundary, shape, Dx, Dy, Dz):
     # Create the empty numpy volume array.
     D = np.empty((shape[1], shape[0], shape[2]), dtype=np.float)
 
-    i_prime, j_prime = np.indices((shape[0], shape[1]))
+    i_prime, j_prime = np.indices((shape[1], shape[0]))
     xP = i_prime * Dx
     yP = j_prime * Dy
 

--- a/solarbextrapolation/extrapolators/potential_field_extrapolator_python.py
+++ b/solarbextrapolation/extrapolators/potential_field_extrapolator_python.py
@@ -29,6 +29,19 @@ def phi_extrapolation_python(boundary, shape, Dx, Dy, Dz):
     Function to extrapolate the scalar magnetic field above the given boundary
     data.
     This implementation runs in python and so is very slow for larger datasets.
+
+    Parameters
+    ----------
+    boundary : array-like
+        Magnetogram boundary data
+    shape : array-like
+        Dimensions of of the extrapolated volume, (nx,ny,nz)
+    Dx : `float`
+        Spacing in x-direction, in units of the boundary map
+    Dy : `float`
+        Spacing in y-direction, in units of the boundary map
+    Dz : `float`
+        Spacing in z-direction, in chosen units
     """
 
     # Derived parameters
@@ -38,7 +51,7 @@ def phi_extrapolation_python(boundary, shape, Dx, Dy, Dz):
     z_submerge = Dz / np.sqrt(2.0 * np.pi)
 
     # Create the empty numpy volume array.
-    D = np.empty((shape[0], shape[1], shape[2]), dtype=np.float)
+    D = np.empty((shape[1], shape[0], shape[2]), dtype=np.float)
 
     i_prime, j_prime = np.indices((shape[0], shape[1]))
     xP = i_prime * Dx
@@ -59,5 +72,5 @@ def phi_extrapolation_python(boundary, shape, Dx, Dy, Dz):
                 G_n = Gn_5_2_29(x, y, z, xP, yP, DxDy, z_submerge)
 
                 # Now add this to the 3D grid.
-                D[i, j, k] = np.sum(boundary * G_n * DxDy)
+                D[j, i, k] = np.sum(boundary * G_n * DxDy)
     return D

--- a/solarbextrapolation/map3dclasses.py
+++ b/solarbextrapolation/map3dclasses.py
@@ -44,13 +44,13 @@ class Map3D(object):
         * cdelt1/2/3: the size of each pixel in each axis.
         * unit1/2/3: the spacial units in each axis.
         * naxis1/2/3: the number of pixels in each axis.
-   
+
     """
     def __init__(self, data, meta, **kwargs):
         self.data = data
         self.meta = meta
-        self.xrange = kwargs.get('xrange', [ 0, data.shape[0] ] * u.pixel)
-        self.yrange = kwargs.get('yrange', [ 0, data.shape[1] ] * u.pixel)
+        self.xrange = kwargs.get('xrange', [ 0, data.shape[1] ] * u.pixel)
+        self.yrange = kwargs.get('yrange', [ 0, data.shape[0] ] * u.pixel)
         self.zrange = kwargs.get('zrange', [ 0, data.shape[2] ] * u.pixel)
         self.xobsrange = kwargs.get('xobsrange', self.xrange)
         self.yobsrange = kwargs.get('yobsrange', self.yrange)
@@ -59,15 +59,15 @@ class Map3D(object):
         self.meta['xrange'] = self.xrange
         self.meta['yrange'] = self.yrange
         self.meta['zrange'] = self.zrange
-        self.meta['cdelt1'] = ((self.xrange[1] - self.xrange[0]) / self.data.shape[0]).value
-        self.meta['cdelt2'] = ((self.yrange[1] - self.yrange[0]) / self.data.shape[1]).value
+        self.meta['cdelt1'] = ((self.xrange[1] - self.xrange[0]) / self.data.shape[1]).value
+        self.meta['cdelt2'] = ((self.yrange[1] - self.yrange[0]) / self.data.shape[0]).value
         self.meta['cdelt3'] = ((self.zrange[1] - self.zrange[0]) / self.data.shape[2]).value
         # Note: should be reversed to fortran array indexing
         self.meta['cunit1'] = self.xrange.unit
         self.meta['cunit2'] = self.yrange.unit
         self.meta['cunit3'] = self.zrange.unit
-        self.meta['naxis1'] = self.data.shape[0]
-        self.meta['naxis2'] = self.data.shape[1]
+        self.meta['naxis1'] = self.data.shape[1]
+        self.meta['naxis2'] = self.data.shape[0]
         self.meta['naxis3'] = self.data.shape[2]
         if kwargs.get('date_obs', False):
             self.meta['date-obs'] = kwargs.get('date_obs')


### PR DESCRIPTION
When going from the 2D boundary map to the 3D extrapolated volume, there are some issues with the confusing the `shape` parameter (usually assumed to be (nx,ny,nz)) with `np.array().shape` which returns (nrows,ncols) (and thus (ny,nx)). See Issue #7 for more details.

This PR fixes these issues in the extrapolator routines, Map3D class, and the example data generator. Now, the dimensions of the boundary map are consistently propagated to the 3D volume.

~~**Note**: This PR also includes a small, but unrelated fix in `utilities.py` that is the subject of PR #5. If this PR is accepted with that change, #5 can be closed and removed~~. 

EDIT: This PR also contains two other minor fixes:

* Python 2-3 compatibility fix in how the config parser is imported
* Unused input argument angle-to-length conversion
