### PR TITLE
Fix (x, y) dimension mismatch in Extrapolator, Map3D, and Example_data_generator

### DIFF
--- a/examples/potential_extrapolation_of_example_data.py
+++ b/examples/potential_extrapolation_of_example_data.py
@@ -33,9 +33,9 @@ import numpy as np
 # quantities.
 
 # Input parameters:
-arr_grid_shape = [ 20, 22, 20 ]         # [ y-size, x-size ]
-xrange = u.Quantity([ -10.0, 10.0 ] * u.arcsec)
-yrange = u.Quantity([ -11.0, 11.0 ] * u.arcsec)
+arr_grid_shape = [ 22, 20, 20 ]         # [ x-size, y-size ]
+xrange = u.Quantity([ -11.0, 11.0 ] * u.arcsec)
+yrange = u.Quantity([ -10.0, 10.0 ] * u.arcsec)
 zrange = u.Quantity([ 0,     20.0 ] * u.arcsec)
 
 ##############################################################################

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
+[tool:pytest]
 minversion = 2.2
 norecursedirs = build docs/_build docs/auto_examples examples
 doctest_plus = enabled

--- a/solarbextrapolation/example_data_generator.py
+++ b/solarbextrapolation/example_data_generator.py
@@ -80,7 +80,7 @@ def generate_example_data(shape, xrange, yrange, *argv):
         arr_poles = arr_args
 
     # Build the empty data array
-    arr_data = np.zeros((shape[1], shape[0]))
+    arr_data = np.zeros((shape[0], shape[1]))
 
     # Grid pixel shape
     qua_pixel = u.Quantity([ ( xrange[1] - xrange[0] ) / shape[0], ( yrange[1] - yrange[0] ) / shape[1] ])
@@ -97,8 +97,8 @@ def generate_example_data(shape, xrange, yrange, *argv):
 
 
     # Iterate through the 2D array/matrix.
-    for i in range(0,shape[0]):     # Row/Y
-        for j in range(0,shape[1]): # Column/X
+    for i in range(0,shape[0]):     # Row/X
+        for j in range(0,shape[1]): # Column/Y
             # The current position
             floXPrime = i * qua_pixel[0]
             floYPrime = j * qua_pixel[1]
@@ -123,7 +123,7 @@ def generate_example_data(shape, xrange, yrange, *argv):
                 flo_value += flo_An_cont
 
             # Now add this to the data array.
-            arr_data[j][i] = flo_value
+            arr_data[i][j] = flo_value
 
     # Now return the 2D numpy array.
     return arr_data
@@ -170,9 +170,9 @@ def dummyDataToMap(data, xrange, yrange, **kwargs):
 if __name__ == '__main__':
     # Generate an example map
     # The input parameters:
-    arr_grid_shape = [ 20, 22 ]         # [ y-size, x-size ]
-    qua_xrange = u.Quantity([ -10.0, 10.0 ] * u.arcsec)
-    qua_yrange = u.Quantity([ -11.0, 11.0 ] * u.arcsec)
+    arr_grid_shape = [ 22, 20 ]         # [ x-size, y-size ]
+    qua_xrange = u.Quantity([ -11.0, 11.0 ] * u.arcsec)
+    qua_yrange = u.Quantity([ -10.0, 10.0 ] * u.arcsec)
 
     # Manual Pole Details
     #arrA0 = [ u.Quantity([ 1.0, 1.0 ] * u.arcsec), 2.0 * u.arcsec, 0.2 * u.T ]

--- a/solarbextrapolation/extrapolators/base.py
+++ b/solarbextrapolation/extrapolators/base.py
@@ -84,7 +84,7 @@ class Extrapolators(object):
         # Crop the boundary data if required.
         self.xrange = kwargs.get('xrange', self.map_boundary_data.xrange)
         self.yrange = kwargs.get('yrange', self.map_boundary_data.yrange)
-        self.map_boundary_data = self.map_boundary_data.submap(self.xrange, self.yrange)
+        # self.map_boundary_data = self.map_boundary_data.submap(self.xrange, self.yrange)
         self.xobsrange = self.map_boundary_data.xrange
         self.yobsrange = self.map_boundary_data.yrange
 
@@ -92,8 +92,8 @@ class Extrapolators(object):
         #print 'help(u): ' + str(help(u))
         #print '\n\n'
         self.zrange = kwargs.get('zrange', u.Quantity([0.0, 1.0] * u.Mm) )
-        self.shape = np.asarray([self.map_boundary_data.data.shape[1],
-                      self.map_boundary_data.data.shape[0],
+        self.shape = np.asarray([self.map_boundary_data.data.shape[0],
+                      self.map_boundary_data.data.shape[1],
                       long(kwargs.get('zshape', 1L))])
         self.filepath = kwargs.get('filepath', None)
         self.routine = kwargs.get('extrapolator_routine', type(self))

--- a/solarbextrapolation/extrapolators/potential_field_extrapolator_numba.py
+++ b/solarbextrapolation/extrapolators/potential_field_extrapolator_numba.py
@@ -19,7 +19,7 @@ def phi_extrapolation_numba(boundary, shape, Dx, Dy, Dz):
     """
 
     # Create the empty numpy volume array.
-    D = np.empty((shape[1], shape[0], shape[2]), dtype=np.float)
+    D = np.empty((shape[0], shape[1], shape[2]), dtype=np.float)
 
     D = outer_loop(D, Dx, Dy, Dz, boundary)
 
@@ -32,8 +32,8 @@ def outer_loop(D, Dx, Dy, Dz, boundary):
     # From Sakurai 1982 P306, we submerge the monopole
     z_submerge = Dz / np.sqrt(2.0 * np.pi)
     # Iterate though the 3D space.
-    for i in range(0, shape[1]):
-        for j in range(0, shape[0]):
+    for i in range(0, shape[0]):
+        for j in range(0, shape[1]):
             for k in range(0, shape[2]):
                 # Position of point in 3D space
                 x = i * Dx
@@ -41,7 +41,7 @@ def outer_loop(D, Dx, Dy, Dz, boundary):
                 z = k * Dz
 
                 # Now add this to the 3D grid.
-                D[j, i, k] = inner_loop(shape, Dx, Dy, x, y, z, boundary, z_submerge)
+                D[i, j, k] = inner_loop(shape, Dx, Dy, x, y, z, boundary, z_submerge)
     return D
 
 
@@ -51,14 +51,14 @@ def inner_loop(shape, Dx, Dy, x, y, z, boundary, z_submerge):
     # Variable holding running total for the contributions to point.
     point_phi_sum = 0.0
     # Iterate through the boundary data.
-    for i_prime in range(0, shape[1]):
-        for j_prime in range(0, shape[0]):
+    for i_prime in range(0, shape[0]):
+        for j_prime in range(0, shape[1]):
             # Position of contributing point on 2D boundary
             xP = i_prime * Dx
             yP = j_prime * Dy
 
             # Find the components for this contribution product
-            B_n = boundary[j_prime, i_prime]
+            B_n = boundary[i_prime, j_prime]
             G_n = Gn_5_2_29(x, y, z, xP, yP, DxDy, z_submerge)
 
             # Add the contributions

--- a/solarbextrapolation/extrapolators/potential_field_extrapolator_python.py
+++ b/solarbextrapolation/extrapolators/potential_field_extrapolator_python.py
@@ -51,9 +51,9 @@ def phi_extrapolation_python(boundary, shape, Dx, Dy, Dz):
     z_submerge = Dz / np.sqrt(2.0 * np.pi)
 
     # Create the empty numpy volume array.
-    D = np.empty((shape[1], shape[0], shape[2]), dtype=np.float)
+    D = np.empty((shape[0], shape[1], shape[2]), dtype=np.float)
 
-    i_prime, j_prime = np.indices((shape[1], shape[0]))
+    i_prime, j_prime = np.indices((shape[0], shape[1]))
     xP = i_prime * Dx
     yP = j_prime * Dy
 
@@ -72,5 +72,5 @@ def phi_extrapolation_python(boundary, shape, Dx, Dy, Dz):
                 G_n = Gn_5_2_29(x, y, z, xP, yP, DxDy, z_submerge)
 
                 # Now add this to the 3D grid.
-                D[j, i, k] = np.sum(boundary * G_n * DxDy)
+                D[i, j, k] = np.sum(boundary * G_n * DxDy)
     return D

--- a/solarbextrapolation/map3dclasses.py
+++ b/solarbextrapolation/map3dclasses.py
@@ -49,8 +49,8 @@ class Map3D(object):
     def __init__(self, data, meta, **kwargs):
         self.data = data
         self.meta = meta
-        self.xrange = kwargs.get('xrange', [ 0, data.shape[1] ] * u.pixel)
-        self.yrange = kwargs.get('yrange', [ 0, data.shape[0] ] * u.pixel)
+        self.xrange = kwargs.get('xrange', [ 0, data.shape[0] ] * u.pixel)
+        self.yrange = kwargs.get('yrange', [ 0, data.shape[1] ] * u.pixel)
         self.zrange = kwargs.get('zrange', [ 0, data.shape[2] ] * u.pixel)
         self.xobsrange = kwargs.get('xobsrange', self.xrange)
         self.yobsrange = kwargs.get('yobsrange', self.yrange)
@@ -59,15 +59,15 @@ class Map3D(object):
         self.meta['xrange'] = self.xrange
         self.meta['yrange'] = self.yrange
         self.meta['zrange'] = self.zrange
-        self.meta['cdelt1'] = ((self.xrange[1] - self.xrange[0]) / self.data.shape[1]).value
-        self.meta['cdelt2'] = ((self.yrange[1] - self.yrange[0]) / self.data.shape[0]).value
+        self.meta['cdelt1'] = ((self.xrange[1] - self.xrange[0]) / self.data.shape[0]).value
+        self.meta['cdelt2'] = ((self.yrange[1] - self.yrange[0]) / self.data.shape[1]).value
         self.meta['cdelt3'] = ((self.zrange[1] - self.zrange[0]) / self.data.shape[2]).value
         # Note: should be reversed to fortran array indexing
         self.meta['cunit1'] = self.xrange.unit
         self.meta['cunit2'] = self.yrange.unit
         self.meta['cunit3'] = self.zrange.unit
-        self.meta['naxis1'] = self.data.shape[1]
-        self.meta['naxis2'] = self.data.shape[0]
+        self.meta['naxis1'] = self.data.shape[0]
+        self.meta['naxis2'] = self.data.shape[1]
         self.meta['naxis3'] = self.data.shape[2]
         if kwargs.get('date_obs', False):
             self.meta['date-obs'] = kwargs.get('date_obs')


### PR DESCRIPTION
Two fixes are included in this PR:

1. Change the order of x-axis and y-axis in Extrapolator, Map3D, and Example_data_generator to ensure the order is (x, y) in all of them.

2. In pytest >= 4.0.0 (it is 4.3.1 on Anaconda currently), feature [pytest] in setup.cfg is replaced with [tool:pytest] (here is the [reference](https://docs.pytest.org/en/latest/deprecations.html#pytest-section-in-setup-cfg-files)). So I change the feature's name in `setup.cfg` to make sure the tests work.